### PR TITLE
Add Expiring property wrapper

### DIFF
--- a/Sources/Utils/Expiring.swift
+++ b/Sources/Utils/Expiring.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A value that periodically expires and gets re-queried
+/// through a supplied getter.
+@propertyWrapper
+public struct Expiring<T> {
+    public let expiryInterval: TimeInterval
+    public private(set) var nextExpiry: Date!
+    private var expired: Bool { nextExpiry.timeIntervalSinceNow < 0 }
+
+    private let getter: () -> T
+    private var cachedValue: T!
+    public var wrappedValue: T {
+        mutating get {
+            if expired {
+                update()
+            }
+            return cachedValue
+        }
+    }
+
+    public init(wrappedValue getter: @autoclosure @escaping () -> T, in expiryInterval: TimeInterval = 1.0) {
+        self.getter = getter
+        self.expiryInterval = expiryInterval
+        update()
+    }
+
+    private mutating func update() {
+        cachedValue = getter()
+        nextExpiry = Date(timeInterval: expiryInterval, since: Date())
+    }
+}


### PR DESCRIPTION
Add a property wrapper `Expiring` that allows for values to be automatically regenerated if the last access was longer than x seconds ago. For example:

```swift
struct X {
    @Expiring(in: 3.0) var value = performHeavyOperation()
}
```

```swift
var x = X()
x.value // Performs initial refresh
x.value // (after 2 seconds) no refresh
x.value // (after 4 seconds) performs refresh
```