### PR TITLE
Make `swift-utils` compile under the Swift 6 language mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        swift: ['5.9', '5.10', '6.0']
+        swift: ['5.10', '6.0']
 
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        swift: ['5.9']
+        swift: ['5.9', '5.10']
 
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        swift: ['5.7', '5.9']
+        swift: ['5.9']
 
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        swift: ['5.9', '5.10']
+        swift: ['5.9', '5.10', '6.0']
 
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "173f567a2dfec11d74588eea82cecea555bdc0bc",
-        "version" : "1.4.0"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "774dc9c7213085db8aa59595e27c1cd22e428904",
-        "version" : "2.3.2"
+        "revision" : "3c2c7e1e72b8abd96eafbae80323c5c1e5317437",
+        "version" : "2.7.5"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
       "state" : {
-        "revision" : "b8fa7fe4c0849f8a64cc246e71c5d976809222e4",
-        "version" : "0.12.0"
+        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
+        "version" : "0.17.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,9 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.1.0"),
-        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
-        .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", from: "0.12.0"),
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.5"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
+        .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", from: "0.17.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Utils/Collections/AvlTree.swift
+++ b/Sources/Utils/Collections/AvlTree.swift
@@ -1,4 +1,4 @@
-import Logging
+@preconcurrency import Logging
 
 fileprivate let log = Logger(label: "Utils.AvlTree")
 

--- a/Sources/Utils/Extensions/StringProtocol+Extensions.swift
+++ b/Sources/Utils/Extensions/StringProtocol+Extensions.swift
@@ -2,7 +2,7 @@ import Foundation
 
 fileprivate let asciiCharacters = CharacterSet(charactersIn: " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")
 fileprivate let quotes = CharacterSet(charactersIn: "\"'`")
-fileprivate let markdownEscapable = #/[\[\]*_]/#
+nonisolated(unsafe) fileprivate let markdownEscapable = #/[\[\]*_]/#
 
 extension StringProtocol {
     public var withFirstUppercased: String {

--- a/Sources/Utils/Filesystem/TemporaryDirectory.swift
+++ b/Sources/Utils/Filesystem/TemporaryDirectory.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Logging
+@preconcurrency import Logging
 
 fileprivate let log = Logger(label: "Utils.TemporaryDirectory")
 

--- a/Sources/Utils/Filesystem/TemporaryFile.swift
+++ b/Sources/Utils/Filesystem/TemporaryFile.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Logging
+@preconcurrency import Logging
 
 fileprivate let log = Logger(label: "Utils.TemporaryFile")
 

--- a/Sources/Utils/Networking/AddressUtils.swift
+++ b/Sources/Utils/Networking/AddressUtils.swift
@@ -1,4 +1,4 @@
-fileprivate let hostPortPattern = #/([^:]+)(?::(\d+))?/#
+nonisolated(unsafe) fileprivate let hostPortPattern = #/([^:]+)(?::(\d+))?/#
 
 public func parseHostPort(from raw: String) -> (String, Int32?)? {
     (try? hostPortPattern.firstMatch(in: raw)).map {

--- a/Sources/Utils/Numerics/Complex.swift
+++ b/Sources/Utils/Numerics/Complex.swift
@@ -1,6 +1,6 @@
 /// A complex number, i.e. an element of the algebraic
 /// closure of the real numbers.
-public struct Complex: SignedNumeric, Addable, Subtractable, Multipliable, Divisible, Negatable, Absolutable, Hashable, ExpressibleByFloatLiteral, CustomStringConvertible {
+public struct Complex: SignedNumeric, Addable, Subtractable, Multipliable, Divisible, Negatable, Absolutable, Hashable, ExpressibleByFloatLiteral, CustomStringConvertible, Sendable {
     public static let i = Complex(0, i: 1)
     public var real: Double
     public var imag: Double

--- a/Sources/Utils/Numerics/MathUtils.swift
+++ b/Sources/Utils/Numerics/MathUtils.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Logging
+@preconcurrency import Logging
 
 fileprivate let log = Logger(label: "Utils.MathUtils")
 

--- a/Sources/Utils/Numerics/NDArrayParser.swift
+++ b/Sources/Utils/Numerics/NDArrayParser.swift
@@ -1,10 +1,10 @@
 import RegexBuilder
 
-fileprivate let rawDecimalPattern = #/-?\d+(?:\.\d+)?/#
-fileprivate let rawFractionPattern = #/-?\d+/\d+/#
+nonisolated(unsafe) fileprivate let rawDecimalPattern = #/-?\d+(?:\.\d+)?/#
+nonisolated(unsafe) fileprivate let rawFractionPattern = #/-?\d+/\d+/#
 // Order of rawFractionPattern and rawDecimalPattern below matters since
 // otherwise numerator and denominator would get parsed as separate tokens
-fileprivate let tokenPattern = Regex {
+nonisolated(unsafe) fileprivate let tokenPattern = Regex {
     ChoiceOf {
         #/[(),]/#
         rawFractionPattern

--- a/Sources/Utils/Numerics/Rational.swift
+++ b/Sources/Utils/Numerics/Rational.swift
@@ -1,5 +1,5 @@
-fileprivate let decimalPattern = #/(?<sign>-?)\s*(?<characteristic>\d+)(?:\.(?<mantissa>\d+))?/#
-fileprivate let fractionPattern = #/(?<numerator>-?\s*\d+)\s*/\s*(?<denominator>-?\s*\d+)/#
+nonisolated(unsafe) fileprivate let decimalPattern = #/(?<sign>-?)\s*(?<characteristic>\d+)(?:\.(?<mantissa>\d+))?/#
+nonisolated(unsafe) fileprivate let fractionPattern = #/(?<numerator>-?\s*\d+)\s*/\s*(?<denominator>-?\s*\d+)/#
 
 fileprivate let reduceThreshold = 1000
 

--- a/Sources/Utils/Ranges/RangeUtils.swift
+++ b/Sources/Utils/Ranges/RangeUtils.swift
@@ -1,5 +1,5 @@
-fileprivate let intRangePattern = #/(\d+)\.\.<(\d+)/#
-fileprivate let closedIntRangePattern = #/(\d+)\.\.\.(\d+)/#
+nonisolated(unsafe) fileprivate let intRangePattern = #/(\d+)\.\.<(\d+)/#
+nonisolated(unsafe) fileprivate let closedIntRangePattern = #/(\d+)\.\.\.(\d+)/#
 
 public func parseIntRange(from str: String) -> Range<Int>? {
     if let rawBounds = try? intRangePattern.firstMatch(in: str) {

--- a/Sources/Utils/Scheduling/RepeatingTimer.swift
+++ b/Sources/Utils/Scheduling/RepeatingTimer.swift
@@ -1,6 +1,9 @@
 import Dispatch
 
+@MainActor
 fileprivate var globalTimerIndex: Int = 0
+
+// TODO: Reimplement this in terms of Swift Concurrency
 
 public class RepeatingTimer {
     public let interval: DispatchTimeInterval
@@ -17,6 +20,7 @@ public class RepeatingTimer {
         }
     }
 
+    @MainActor
     public func schedule(nTimes n: Int = 1, beginImmediately: Bool = true, action: @escaping (Int, TimerContext) -> Void) {
         // (Re)start timer
         let queue = DispatchQueue(label: "RepeatingTimer #\(globalTimerIndex)")

--- a/Sources/Utils/Serialization/AutoSerializing.swift
+++ b/Sources/Utils/Serialization/AutoSerializing.swift
@@ -1,4 +1,4 @@
-import Logging
+@preconcurrency import Logging
 
 fileprivate let log = Logger(label: "Utils.AutoSerializing")
 

--- a/Sources/Utils/Synchronization/MutexLock.swift
+++ b/Sources/Utils/Synchronization/MutexLock.swift
@@ -1,7 +1,7 @@
 import Dispatch
 
 /// A basic synchronization primitive.
-public struct MutexLock {
+public struct MutexLock: Sendable {
     private let semaphore = DispatchSemaphore(value: 1)
 
     /// Acquires the lock for the duration of the given block.

--- a/Sources/Utils/Web/DocumentToMarkdownConverter.swift
+++ b/Sources/Utils/Web/DocumentToMarkdownConverter.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SwiftSoup
+@preconcurrency import SwiftSoup
 
 /**
  * Converts HTML documents into Markdown.

--- a/Sources/Utils/Web/HTTPRequest.swift
+++ b/Sources/Utils/Web/HTTPRequest.swift
@@ -5,7 +5,7 @@ import FoundationNetworking
 #if canImport(FoundationXML)
 import FoundationXML
 #endif
-import SwiftSoup
+@preconcurrency import SwiftSoup
 import XMLCoder
 
 public struct HTTPRequest {

--- a/Sources/Utils/Web/HTTPRequest.swift
+++ b/Sources/Utils/Web/HTTPRequest.swift
@@ -115,13 +115,13 @@ public struct HTTPRequest {
     }
 
     /// Runs the request and asynchronously decodes the response as JSON.
-    public func fetchJSON<T>(as type: T.Type) async throws -> T where T: Decodable {
+    public func fetchJSON<T>(as type: T.Type) async throws -> T where T: Decodable & Sendable {
         try await fetchJSONAsync(as: type).get()
     }
 
     /// Runs the request and returns a `Promise` with the value decoded from the
     /// response interpreted as JSON.
-    public func fetchJSONAsync<T>(as type: T.Type) -> Promise<T, Error> where T: Decodable {
+    public func fetchJSONAsync<T>(as type: T.Type) -> Promise<T, Error> where T: Decodable & Sendable {
         runAsync().mapCatching {
             do {
                 return try JSONDecoder().decode(type, from: $0)
@@ -132,18 +132,18 @@ public struct HTTPRequest {
     }
 
     /// Runs the request and asynchronously decodes the response as XML.
-    public func fetchXML<T>(as type: T.Type) async throws -> T where T: Decodable {
+    public func fetchXML<T>(as type: T.Type) async throws -> T where T: Decodable & Sendable {
         try await fetchXMLAsync(as: type).get()
     }
 
     /// Runs the request and returns a `Promise` with the value decoded from the
     /// response interpreted as XML.
-    public func fetchXMLAsync<T>(as type: T.Type) -> Promise<T, Error> where T: Decodable {
+    public func fetchXMLAsync<T>(as type: T.Type) -> Promise<T, Error> where T: Decodable & Sendable {
         runAsync().mapCatching { try XMLDecoder().decode(type, from: $0) }
     }
 
     /// Runs the request and interprets the response as XML via the given delegate.
-    public func fetchXMLAsync(using delegate: XMLParserDelegate) {
+    public func fetchXMLAsync(using delegate: any XMLParserDelegate & Sendable) {
         runAsync().listen {
             switch $0 {
                 case .success(let data):


### PR DESCRIPTION
This fixes all concurrency-related issues and makes the library compile under the Swift 6 language mode. Additionally:

- The dependencies are bumped (since some of them include Swift 6-relevant fixes)
- The minimum version of Swift is bumped to 5.10 (since this is the oldest source-compatible version that supports `nonisolated(unsafe)`)

To fully enable it, we'll have to enable the language mode too, though, which also bumps the required Swift version to 6.0:

```diff
diff --git a/Package.swift b/Package.swift
index e8db2a8..cb0139a 100644
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -29,6 +29,9 @@
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "SwiftSoup", package: "SwiftSoup"),
                 .product(name: "XMLCoder", package: "XMLCoder"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
             ]
         ),
         .testTarget(

```

Hence why we defer this to a future PR[^1].

[^1]: Side note: Unfortunately building with `swift build -Xswiftc -swift-version -Xswiftc 6` as suggested in the migration guide is not sufficient as this will also try building dependencies like `swift-log` in Swift 6 language mode.